### PR TITLE
updated to correct QSS3KeyPrefix

### DIFF
--- a/templates/quickstart-chainlink-node-workload.template.yaml
+++ b/templates/quickstart-chainlink-node-workload.template.yaml
@@ -448,7 +448,7 @@ Parameters:
     AllowedPattern: ^([0-9a-zA-Z-.]+/)*$
     ConstraintDescription: The Quick Start S3 key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slashes (/).
-    Default: quickstart-chainlink-node/
+    Default: quickstart-chainlinklabs-chainlink-node/
     Description: S3 key prefix that is used to simulate a directory for your copy of the
       Quick Start assets. Keep the default prefix unless you are customizing
       the template. Changing this prefix updates code references to point to


### PR DESCRIPTION
*Issue #, if available:*
Workload template is unable to deploy into existing VPC. Quick Start stack runs into error:
`S3 error: The specified key does not exist. For more information check http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html`

*Description of changes:*
Updated to the correct QSS3KeyPrefix default parameter value in `quickstart-chainlink-node-workload.template.yaml` on line 451:
`Default: quickstart-chainlink-node/` -> `Default: quickstart-chainlinklabs-chainlink-node/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
