### PR TITLE
hotfix to support non-root CL container and fixed command error in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.15">
-<title>Chainlink node on the AWS Cloud</title>
+<title>Chainlink Node on the AWS Cloud</title>
 <style>
 
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -825,7 +825,7 @@ p.footer-text a{color:#d7d8d8}
 <div id="toctitle"></div>
 <ul class="sectlevel1">
 <li><a href="#_overview">Overview</a></li>
-<li><a href="#_chainlink_node_on_aws">Chainlink node on AWS</a></li>
+<li><a href="#_chainlink_node_on_aws">Chainlink Node on AWS</a></li>
 <li><a href="#_aws_costs">AWS costs</a></li>
 <li><a href="#_software_licenses">Software licenses</a></li>
 <li><a href="#_architecture">Architecture</a></li>
@@ -845,17 +845,17 @@ p.footer-text a{color:#d7d8d8}
 <li><a href="#_post_deployment_steps">Post-deployment steps</a>
 <ul class="sectlevel2">
 <li><a href="#_access_your_chainlink_node">Access your Chainlink node</a></li>
-<li><a href="#_fulfilling_requests_with_the_chainlink_node">Fulfilling requests with the Chainlink node</a></li>
-<li><a href="#_working_with_external_adapters">Working with external adapters</a></li>
-<li><a href="#_manually_creating_your_env_password_and_api_files_for_chainlink_node_instances">Manually creating your .env, .password, and .api files for Chainlink node instances</a></li>
-<li><a href="#_docker_run_command_to_start_chainlink_node_instances">Docker run command to start Chainlink node instances</a></li>
+<li><a href="#_fulfill_requests_with_the_chainlink_node">Fulfill requests with the Chainlink node</a></li>
+<li><a href="#_work_with_external_adapters">Work with external adapters</a></li>
+<li><a href="#_manually_create_files_for_chainlink_node_instances">Manually create files for Chainlink node instances</a></li>
+<li><a href="#_start_chainlink_node_instances">Start Chainlink node instances</a></li>
 </ul>
 </li>
 <li><a href="#_best_practices_for_using_chainlink_node_on_aws">Best practices for using Chainlink node on AWS</a>
 <ul class="sectlevel2">
-<li><a href="#_failover_capabilities">Failover Capabilities</a></li>
-<li><a href="#_disaster_recovery">Disaster Recovery</a></li>
-<li><a href="#_active_monitoring">Active Monitoring</a></li>
+<li><a href="#_failover_capabilities">Failover capabilities</a></li>
+<li><a href="#_disaster_recovery">Disaster recovery</a></li>
+<li><a href="#_active_monitoring">Active monitoring</a></li>
 </ul>
 </li>
 <li><a href="#_security">Security</a></li>
@@ -872,7 +872,7 @@ p.footer-text a{color:#d7d8d8}
 <div id="content">
 <div id="preamble">
 <div class="sectionbody">
-<h2 id="_chainlink_node_on_the_aws_cloud" class="discrete text-center">Chainlink node on the AWS Cloud</h2>
+<h2 id="_chainlink_node_on_the_aws_cloud" class="discrete text-center">Chainlink Node on the AWS Cloud</h2>
 <h2 id="_quick_start_reference_deployment" class="discrete text-left text-center">Quick Start Reference Deployment</h2>
 <div class="imageblock text-center">
 <div class="content">
@@ -890,8 +890,10 @@ p.footer-text a{color:#d7d8d8}
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph text-center">
-<p><strong>August 2021</strong><br>
-<em>AWS Quick Start team</em></p>
+<p><strong>September 2021</strong><br>
+<em>David Dang, Rodger Johnson, Chainlink Labs</em><br>
+<em>Vijay Krishnan, AWS Solutions Architect</em><br>
+<em>Troy Ameigh, AWS Solutions Architect, Integration and Automation Team</em></p>
 </div></div></td>
 </tr>
 </tbody>
@@ -930,7 +932,7 @@ report bugs, or submit feature ideas for this Quick Start.
 <p>This guide provides instructions for deploying the Chainlink node Quick Start reference architecture on the AWS Cloud.</p>
 </div>
 <div class="paragraph">
-<p>This Quick Start is for users who enterprise users that want to run a highly available and secure Chainlink node.</p>
+<p>This Quick Start deploys highly available Chainlink nodes with default parameters and a blockchain to the AWS Cloud. It is for enterprise users who want to run a secure Chainlink node to provide external resources such as external APIs, tamper-proof price data, and verifiable randomness directly to smart contracts stored on the blockchain.</p>
 </div></div></td>
 </tr>
 </tbody>
@@ -950,7 +952,7 @@ Amazon may share user-deployment information with the AWS Partner that collabora
 </div>
 </div>
 <div class="sect1">
-<h2 id="_chainlink_node_on_aws">Chainlink node on AWS</h2>
+<h2 id="_chainlink_node_on_aws">Chainlink Node on AWS</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p><em><strong>This portion of the deployment guide is located at <code>docs/partner_editable/product_description.adoc</code></strong></em></p>
@@ -962,13 +964,13 @@ Amazon may share user-deployment information with the AWS Partner that collabora
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Chainlink is a data oracle that enables smart contracts on any blockchain to leverage extensive off-chain resources, such as tamper-proof price data, verifiable randomness, and external APIs.</p>
+<p>Chainlink is a data oracle that enables smart contracts on any blockchain to take advantage of extensive off-chain resources, such as tamper-proof price data, verifiable randomness, and external APIs.</p>
 </div>
 <div class="paragraph">
-<p>When deployed to a blockchain, a smart contract is a set of instructions that can be executed without intervention from third parties. The code of a smart contract determines how it responds to input, just like the code of any other computer program.</p>
+<p>When deployed to a blockchain, a smart contract is a set of instructions that can be run without intervention from third parties. The code of a smart contract determines how it responds to input, just like the code of any other computer program.</p>
 </div>
 <div class="paragraph">
-<p>The Chainlink node is middleware, operating between the blockchain and external data. Node operators are able to run their Chainlink nodes with oracle job specifications, or specs, which contain the sequential tasks that the node must perform to produce a final result. The Chainlink node provide external data directly to smart contracts.</p>
+<p>The Chainlink node is middleware that operates between the blockchain and external data. Node operators are able to run their Chainlink nodes with oracle job specifications, or specs, which contain the sequential tasks that the node must perform to produce a final result. The Chainlink node provides external data directly to smart contracts.</p>
 </div></div></td>
 </tr>
 </tbody>
@@ -1041,7 +1043,7 @@ AWS Cloud.</p>
 </div>
 <div id="architecture1" class="imageblock">
 <div class="content">
-<img src="images/architecture_diagram_white.png" alt="Architecture">
+<img src="images/chainlink-node-architecture-diagram.png" alt="Architecture">
 </div>
 <div class="title">Figure 1. Quick Start architecture for Chainlink node on AWS</div>
 </div>
@@ -1070,7 +1072,7 @@ internet access for the Chainlink node instances in the private subnets.*</p>
 </li>
 <li>
 <p>A Linux bastion host in an Auto Scaling group to allow inbound Secure
-Shell (SSH) access to EC2 instances in public and private subnets.</p>
+Shell (SSH) access to Amazon Elastic Compute Cloud (Amazon EC2) instances in public and private subnets.</p>
 </li>
 </ul>
 </div>
@@ -1080,28 +1082,25 @@ Shell (SSH) access to EC2 instances in public and private subnets.</p>
 <div class="ulist">
 <ul>
 <li>
-<p>Two Chainlink nodes in an Auto Scaling group.</p>
+<p>Two Chainlink nodes in an Auto Scaling group that contains security groups for fine-grained inbound access control.</p>
 </li>
 <li>
-<p>An Amazon Relation Database Service (Amazon RDS) PostgreSQL managed database instance.</p>
+<p>An Amazon Relational Database Service (Amazon RDS) PostgreSQL managed database instance.</p>
 </li>
 </ul>
 </div>
 </li>
 <li>
-<p>Security groups for fine-grained inbound access control.</p>
-</li>
-<li>
-<p>An Elastic Load Balancing (ELB) load balancer to access the Chainlink node web graphical user interface.</p>
+<p>An Elastic Load Balancing (ELB) load balancer to access the Chainlink node user interface.</p>
 </li>
 <li>
 <p>Amazon CloudWatch logging of Chainlink nodes.</p>
 </li>
 <li>
-<p>AWS managed keys and customer managed keys for resources with AWS Key Management Service (KMS).</p>
+<p>AWS Key Management Service (AWS KMS) resources with both AWS managed and customer managed keys.</p>
 </li>
 <li>
-<p>AWS Secrets Manager to store your credentials.</p>
+<p>AWS Secrets Manager to store credentials.</p>
 </li>
 <li>
 <p>Amazon DevOps Guru tracking of your Chainlink node stack.</p>
@@ -1137,35 +1136,32 @@ deploy, and operate your infrastructure and applications on the AWS Cloud.</p>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>This Quick Start also assumes familiarity with basic concepts in the areas of networking and DevOps. This deployment guide also requires a moderate level of familiarity with AWS services.</p>
+<p>This Quick Start assumes familiarity with networking, DevOps, and <a href="https://docs.chain.link/docs/running-a-chainlink-node/" target="_blank" rel="noopener">Chainlink nodes</a>. It also requires a moderate level of familiarity with the following AWS services:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p><a href="https://aws.amazon.com/ec2/">Amazon EC2</a></p>
+<p><a href="https://aws.amazon.com/ec2/" target="_blank" rel="noopener">Amazon EC2</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/vpc/">Amazon VPC</a></p>
+<p><a href="https://aws.amazon.com/vpc/" target="_blank" rel="noopener">Amazon VPC</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/cloudwatch/">Amazon CloudWatch</a></p>
+<p><a href="https://aws.amazon.com/cloudwatch/" target="_blank" rel="noopener">Amazon CloudWatch</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/devops-guru/">Amazon DevOps Guru</a></p>
+<p><a href="https://aws.amazon.com/devops-guru/" target="_blank" rel="noopener">Amazon DevOps Guru</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/rds/aurora/?aurora-whats-new.sort-by=item.additionalFields.postDateTime&amp;aurora-whats-new.sort-order=desc">Amazon Aurora PostgreSQL</a></p>
+<p><a href="https://aws.amazon.com/rds/aurora/?aurora-whats-new.sort-by=item.additionalFields.postDateTime&amp;aurora-whats-new.sort-order=desc" target="_blank" rel="noopener">Amazon Aurora PostgreSQL</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/cloudformation/">AWS CloudFormation</a></p>
+<p><a href="https://aws.amazon.com/cloudformation/" target="_blank" rel="noopener">AWS CloudFormation</a></p>
 </li>
 </ul>
 </div>
 <div class="paragraph">
-<p>If you’re new to AWS, visit the <a href="https://aws.amazon.com/getting-started/">Getting Started Resource Center</a> and the <a href="https://aws.amazon.com/training/">AWS Training and Certification</a> for materials and programs that can help you develop the skills to design, deploy, and operate your infrastructure and applications on the AWS Cloud.</p>
-</div>
-<div class="paragraph">
-<p>We recommend that you also become familiar with running <a href="https://docs.chain.link/docs/running-a-chainlink-node/">Chainlink nodes</a>.</p>
+<p>If you’re new to AWS, see the <a href="https://aws.amazon.com/getting-started/" target="_blank" rel="noopener">Getting Started Resource Center</a> and the <a href="https://aws.amazon.com/training/" target="_blank" rel="noopener">AWS Training and Certification</a> site for materials and programs that can help you develop the skills to design, deploy, and operate your infrastructure and applications on the AWS Cloud.</p>
 </div></div></td>
 </tr>
 </tbody>
@@ -1247,45 +1243,12 @@ deploy, and operate your infrastructure and applications on the AWS Cloud.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_supported_regions">Supported Regions</h4>
+<h4 id="_supported_aws_regions">Supported AWS Regions</h4>
 <div class="paragraph">
-<p><em><strong>This portion of the deployment guide is located at <code>docs/partner_editable/regions.adoc</code></strong></em></p>
+<p>For any Quick Start to work in a Region other than its default Region, all the services it deploys must be supported in that Region. You can launch a Quick Start in any Region and see if it works. If you get an error such as “Unrecognized resource type,” the Quick Start is not supported in that Region.</p>
 </div>
-<div id="preview_mode">
 <div class="paragraph">
-<p>This Quick Start supports the following Regions:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>us-east-1, US East (N. Virginia)</p>
-</li>
-<li>
-<p>us-east-2, US East (Ohio)</p>
-</li>
-<li>
-<p>us-west-2, US West (Oregon)</p>
-</li>
-<li>
-<p>eu-central-1, Europe (Frankfurt)</p>
-</li>
-<li>
-<p>eu-west-1, Europe (Ireland)</p>
-</li>
-<li>
-<p>eu-north-1, Europe (Stockholm)</p>
-</li>
-<li>
-<p>ap-southeast-1, Asia Pacific (Singapore)</p>
-</li>
-<li>
-<p>ap-southeast-2, Asia Pacific (Tokyo)</p>
-</li>
-<li>
-<p>ap-northeast-1, Asia Pacific (Tokyo)</p>
-</li>
-</ul>
-</div>
+<p>For an up-to-date list of AWS Regions and the AWS services they support, see <a href="https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/" target="_blank" rel="noopener">AWS Regional Services</a>.</p>
 </div>
 <div class="admonitionblock tip">
 <table>
@@ -1305,47 +1268,6 @@ Certain Regions are available on an opt-in basis. For more information, see <a h
 <div class="paragraph">
 <p>Before launching the Quick Start, you must sign in to the AWS Management Console with IAM permissions for the resources that the templates deploy. The <em>AdministratorAccess</em> managed policy within IAM provides sufficient permissions, although your organization may choose to use a custom policy with more restrictions. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html" target="_blank" rel="noopener">AWS managed policies for job functions</a>.</p>
 </div>
-<div class="paragraph">
-<p><em><strong>This portion of the deployment guide is located at <code>docs/partner_editable/pre-reqs.adoc</code></strong></em></p>
-</div>
-<table class="tableblock frame-all grid-all stretch preview_mode">
-<colgroup>
-<col style="width: 100%;">
-</colgroup>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><div class="content"><div id="toc" class="toc">
-<div id="toctitle"></div>
-<ul class="sectlevel3">
-<li><a href="#_prepare_your_aws_account">Prepare your AWS account</a></li>
-</ul>
-</div>
-<div class="sect3">
-<h4 id="_prepare_your_aws_account">Prepare your AWS account</h4>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>If you don’t already have an AWS account, create one at <a href="https://aws.amazon.com" class="bare">https://aws.amazon.com</a> by
-following the on-screen instructions.</p>
-</li>
-<li>
-<p>Create a key pair in your preferred region.</p>
-</li>
-<li>
-<p>If using a domain and SSL certificate, create a public certificate using Amazon Certificate Manager in your preferred region.</p>
-</li>
-<li>
-<p>Run a blockchain client or use a third party client. In the case of a third party Ethereum client, you can use the websocket endpoint from <a href="https://infura.io/docs/ethereum/wss/introduction.md">Infura</a> or <a href="https://docs.fiews.io/docs/getting-started">Fiews</a>. For other Ethereum clients, visit <a href="https://docs.chain.link/docs/run-an-ethereum-client/">Run an Ethereum Client</a>.</p>
-</li>
-<li>
-<p>If using an existing VPC, make sure that it contains two public subnets, two private subnets, internet gateway, NAT gateways, and route tables.</p>
-</li>
-</ol>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect3">
 <h4 id="_deployment_options">Deployment options</h4>
@@ -1373,6 +1295,47 @@ following the on-screen instructions.</p>
 </div>
 <div class="paragraph">
 <p>The Quick Start provides separate templates for these options. It also lets you configure Classless Inter-Domain Routing (CIDR) blocks, instance types, and Chainlink node settings, as discussed later in this guide.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><em><strong>This portion of the deployment guide is located at <code>docs/partner_editable/pre-reqs.adoc</code></strong></em></p>
+</div>
+<table class="tableblock frame-all grid-all stretch preview_mode">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div id="toc" class="toc">
+<div id="toctitle"></div>
+<ul class="sectlevel3">
+<li><a href="#_prepare_your_aws_account">Prepare your AWS account</a></li>
+</ul>
+</div>
+<div class="sect3">
+<h4 id="_prepare_your_aws_account">Prepare your AWS account</h4>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Create an AWS account at <a href="https://aws.amazon.com" class="bare">https://aws.amazon.com</a> by
+following the on-screen instructions.</p>
+</li>
+<li>
+<p>Create a key pair in your preferred Region.</p>
+</li>
+<li>
+<p>If using a domain and SSL certificate, create a public certificate using AWS Certificate Manager (ACM) in your preferred Region.</p>
+</li>
+<li>
+<p>Run a blockchain client or use a third-party client. If using a third-party Ethereum client, you can use the web socket endpoint from <a href="https://infura.io/docs/ethereum/wss/introduction.md" target="_blank" rel="noopener">Infura</a> or <a href="https://docs.fiews.io/docs/getting-started" target="_blank" rel="noopener">Fiews</a>. For other Ethereum clients, see <a href="https://docs.chain.link/docs/run-an-ethereum-client/" target="_blank" rel="noopener">Run an Ethereum Client</a>.</p>
+</li>
+<li>
+<p>If using an existing VPC, make sure that it contains two public subnets, two private subnets, an internet gateway, NAT gateways, and route tables.</p>
+</li>
+</ol>
+</div>
 </div></div></td>
 </tr>
 </tbody>
@@ -1427,17 +1390,17 @@ If you’re deploying Chainlink node into an existing VPC, make sure that your V
 <p>Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see <a href="#_deployment_options">Deployment options</a> earlier in this guide.</p>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 75%;">
-<col style="width: 25%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="http://qs_launch_permalink" target="_blank" rel="noopener">Deploy Chainlink node into a new VPC on AWS</a></p></td>
-<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="http://qs_template_permalink" target="_blank" rel="noopener">View template</a></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="https://fwd.aws/VVEab?" target="_blank" rel="noopener">Deploy Chainlink node into a new VPC on AWS</a></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="https://fwd.aws/8bA3e?" target="_blank" rel="noopener">View template</a></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="http://qs_launch_permalink" target="_blank" rel="noopener">Deploy Chainlink node into an existing VPC on AWS</a></p></td>
-<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="http://qs_template_permalink" target="_blank" rel="noopener">View template</a></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="https://fwd.aws/Veavz?" target="_blank" rel="noopener">Deploy Chainlink node into an existing VPC on AWS</a></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="https://fwd.aws/aX4v6?" target="_blank" rel="noopener">View template</a></p></td>
 </tr>
 </tbody>
 </table>
@@ -1459,7 +1422,7 @@ If you’re deploying Chainlink node into an existing VPC, make sure that your V
 </div>
 <div class="paragraph">
 <p>+
-. On the <strong>Configure stack options</strong> page, you can <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html" target="_blank" rel="noopener">specify tags</a> (key-value pairs) for resources in your stack and <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html" target="_blank" rel="noopener">set advanced options</a>. When you’re finished, choose <strong>Next</strong>.
+. On the <strong>Configure stack options</strong> page, you can <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html" target="_blank" rel="noopener">specify tags</a> (key-value pairs) for resources in your stack and <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html" target="_blank" rel="noopener">set advanced options</a>. When you finish, choose <strong>Next</strong>.
 . On the <strong>Review</strong> page, review and confirm the template settings. Under <strong>Capabilities</strong>, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.
 . Choose <strong>Create stack</strong> to deploy the stack.
 . Monitor the status of the stack. When the status is <strong>CREATE_COMPLETE</strong>, the Chainlink node deployment is ready.
@@ -1478,17 +1441,13 @@ If you’re deploying Chainlink node into an existing VPC, make sure that your V
 <div class="sect2">
 <h3 id="_access_your_chainlink_node">Access your Chainlink node</h3>
 <div class="paragraph">
-<p>You can access your Chainlink node through the web graphical user interface. There are two options on accessing the page.</p>
+<p>You can access the Chainlink node user interface (UI) using one of the following options:</p>
 </div>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>If using a domain and SSL certificate created through AWS Certificate Manager, you can access the Chainlink node web GUI through the application load balancer endpoint or through your domain by adding the load balancer endpoint to your domain&#8217;s DNS record.</p>
-</li>
-<li>
-<p>By enabling TCP port forwarding on your bastion host, you are able to port forward the Chainlink node web GUI to your machine. As we are accessing the Chainlink node through a bastion, it is recommended to use SSH agent forwarding. Then connect to your bastion with SSH agent and TCP port forwarding. You can access the Chainlink node web GUI at <a href="http://localhost:6688/" class="bare">http://localhost:6688/</a>.</p>
-</li>
-</ol>
+<div class="paragraph">
+<p>Option 1: If using a domain and SSL certificate created through ACM, you can access the Chainlink node UI through the Application Load Balancer endpoint or through your domain by adding the load balancer endpoint to your domain&#8217;s DNS record.</p>
+</div>
+<div class="paragraph">
+<p>Option 2: Allow TCP port forwarding on your bastion host to port forward the Chainlink node UI to your machine. When accessing the Chainlink node through a bastion host, use SSH agent forwarding. Then connect to your bastion host with an SSH agent and TCP port forwarding. Access the Chainlink node UI at <a href="http://localhost:6688/" class="bare">http://localhost:6688/</a>.</p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1499,24 +1458,24 @@ ssh ec2-user@&lt;chainlink_node_internal_ip&gt; -L 6688:localhost:6688</pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_fulfilling_requests_with_the_chainlink_node">Fulfilling requests with the Chainlink node</h3>
+<h3 id="_fulfill_requests_with_the_chainlink_node">Fulfill requests with the Chainlink node</h3>
 <div class="paragraph">
-<p>Once the quickstart is deployed, your Chainlink node is ready to interact with smart contracts and <a href="https://docs.chain.link/docs/fulfilling-requests/">fulfill requests</a>.</p>
+<p>After the Quick Start is deployed, your Chainlink node is ready to interact with smart contracts and fulfill requests. For more information, see <a href="https://docs.chain.link/docs/fulfilling-requests/" target="_blank" rel="noopener">Fulfilling Requests</a>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_working_with_external_adapters">Working with external adapters</h3>
+<h3 id="_work_with_external_adapters">Work with external adapters</h3>
 <div class="paragraph">
-<p>External adapters are how Chainlink enables easy integration of custom computations and specialized APIs. External adapters are services which the core of the Chainlink node communicates via its API with a simple JSON specification. To get started, visit our <a href="https://docs.chain.link/docs/external-adapters/">external adapters documentation</a>.</p>
+<p>Chainlink enables integration of custom computations and specialized APIs using external adapters. The Chainlink node communicates with external adapter services via an API using a JSON specification. To get started, see <a href="https://docs.chain.link/docs/external-adapters/" target="_blank" rel="noopener">External Adapters Introduction</a>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_manually_creating_your_env_password_and_api_files_for_chainlink_node_instances">Manually creating your .env, .password, and .api files for Chainlink node instances</h3>
+<h3 id="_manually_create_files_for_chainlink_node_instances">Manually create files for Chainlink node instances</h3>
 <div class="paragraph">
-<p>If the Chainlink node instances are stopped, then new .env, .password, and .api files will need to be created to start the Chainlink node.</p>
+<p>If the Chainlink node instances are stopped, then you must create new .env, .password, and .api files to start the Chainlink node.</p>
 </div>
 <div class="paragraph">
-<p><strong>Generating the .env file:</strong></p>
+<p><strong>Generate the .env file:</strong></p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1531,7 +1490,7 @@ ${psqlDb}</pre>
 </div>
 </div>
 <div class="paragraph">
-<p><strong>Generating the .password file:</strong></p>
+<p><strong>Generate the .password file:</strong></p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1540,7 +1499,7 @@ $(aws secretsmanager get-secret-value --secret-id WalletSecret --query "SecretSt
 </div>
 </div>
 <div class="paragraph">
-<p><strong>Generating the .api file:</strong></p>
+<p><strong>Generate the .api file:</strong></p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1551,9 +1510,9 @@ $(aws secretsmanager get-secret-value --secret-id ApiSecret --query "SecretStrin
 </div>
 </div>
 <div class="sect2">
-<h3 id="_docker_run_command_to_start_chainlink_node_instances">Docker run command to start Chainlink node instances</h3>
+<h3 id="_start_chainlink_node_instances">Start Chainlink node instances</h3>
 <div class="paragraph">
-<p>To manually run the latest image of Chainlink node docker instance:</p>
+<p>To run the latest image of the Chainlink node Docker instance, run this command:</p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1562,11 +1521,12 @@ cd /home/ec2-user/.chainlink &amp;&amp; docker run -d \
 --log-driver=awslogs \
 --log-opt awslogs-group=ChainlinkLogs \
 --restart unless-stopped \
+-u 1000:1000 \
 --name chainlink \
 -p 6688:6688 \
 -v /home/ec2-user/.chainlink:/chainlink \
 --env-file=/home/ec2-user/.chainlink/.env  smartcontract/chainlink:$latestimage local n \
--p /chainlink/.password
+-p /chainlink/.password \
 -a /chainlink/.api</pre>
 </div>
 </div>
@@ -1577,59 +1537,56 @@ cd /home/ec2-user/.chainlink &amp;&amp; docker run -d \
 <h2 id="_best_practices_for_using_chainlink_node_on_aws">Best practices for using Chainlink node on AWS</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_failover_capabilities">Failover Capabilities</h3>
+<h3 id="_failover_capabilities">Failover capabilities</h3>
 <div class="paragraph">
-<p>To ensure there is very minimal downtime, failover capabilities are required on both the Chainlink and Ethereum clients so that if any one server fails, the service is still online. The Amazon EC2 Auto Scaling group has two Chainlink nodes: one active Chainlink node and one standby Chainlink node. Data from both the Chainlink and Ethereum clients are stored in a PostgreSQL database which needs to be highly available.</p>
+<p>To reduce downtime, failover capabilities are required on both the Chainlink and Ethereum clients so that if one server fails, the service is still online. The Amazon EC2 Auto Scaling group has two Chainlink nodes: one active Chainlink node and one standby Chainlink node. Data from both the Chainlink and Ethereum clients are stored in a highly available PostgreSQL database.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_disaster_recovery">Disaster Recovery</h3>
+<h3 id="_disaster_recovery">Disaster recovery</h3>
 <div class="paragraph">
-<p>Problems occur and when they do, the right processes need to be in-place to ensure that as little downtime as possible occurs. The main impediment to incurring large amounts of downtime in the context of Chainlink node operators is a fully corrupted Ethereum node that requires a re-sync.</p>
+<p>If problems occur, the right processes must be in place to reduce downtime. The most common reason for downtime (in the context of Chainlink node operators) is a corrupted Ethereum node that requires a resynchronization.</p>
 </div>
 <div class="paragraph">
-<p>Due to the challenge of recovering an Ethereum client, we recommend:</p>
+<p>To recover an Ethereum client and reduce downtime, follow these recommendations:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p>Daily snapshots of the Ethereum chain on a separate server than what the Chainlink node is connected to.</p>
+<p>Take daily snapshots of the Ethereum chain on a separate server than the one connected to the Chainlink node.</p>
 </li>
 <li>
-<p>An Ethereum client start-up process that pulls down the latest template of the chain and syncs it to the latest height.</p>
+<p>Use an Ethereum client start-up process that pulls down the latest template of the chain and syncs it to the latest height.</p>
 </li>
 </ul>
 </div>
-<div class="paragraph">
-<p>With this process in-place, the elapsed time of full disaster is kept to a minimum.</p>
-</div>
 </div>
 <div class="sect2">
-<h3 id="_active_monitoring">Active Monitoring</h3>
+<h3 id="_active_monitoring">Active monitoring</h3>
 <div class="paragraph">
-<p>To be proactive in detecting any issues before or when they occur, active monitoring needs to be in place. The areas where we recommend to monitor are:</p>
+<p>To detect issues before or when they occur, use active monitoring in the following areas:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p>(Minimum Required) ETH balance of the wallet address assigned to the node.</p>
+<p>(Minimum required) Ethereum of the wallet address assigned to the node.</p>
 </li>
 <li>
 <p>Errored job runs.</p>
 </li>
 <li>
-<p>Operator UI port to be open and responsive. (Usually: 6688)</p>
+<p>Operator UI port to be open and responsive (usually 6688).</p>
 </li>
 <li>
-<p>Ethereum http and websocket ports to be open and responsive. (Usually: 8545 &amp; 8546)</p>
+<p>Ethereum HTTP and web socket ports to be open and responsive (usually 8545 and 8546).</p>
 </li>
 <li>
-<p>Ethereum client disk, RAM and CPU usage.</p>
+<p>Ethereum client disk, RAM, and CPU usage.</p>
 </li>
 </ul>
 </div>
 <div class="paragraph">
-<p>Monitoring of the Chainlink nodes are available through Amazon CloudWatch.</p>
+<p>You can use Amazon CloudWatch to monitor Chainlink nodes.</p>
 </div>
 </div>
 </div>
@@ -1638,7 +1595,7 @@ cd /home/ec2-user/.chainlink &amp;&amp; docker run -d \
 <h2 id="_security">Security</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>The Chainlink node docker instance requires the .env, .password, and .api file that contains plaintext passwords. It is recommended to remove the .env, .password, and .api files once the Chainlink node instance is running to prevent potential exposure of sensitive passwords.</p>
+<p>The Chainlink node Docker instance requires the .env, .password, and .api file that contains plaintext passwords. Remove the .env, .password, and .api files after the Chainlink node instance is running to prevent potential exposure of sensitive passwords.</p>
 </div>
 <div class="paragraph">
 <p><em><strong>This portion of the deployment guide is located at <code>docs/partner_editable/faq_troubleshooting.adoc</code></strong></em></p>
@@ -1680,13 +1637,13 @@ When you set <strong>Rollback on failure</strong> to <strong>Disabled</strong>, 
 <p><strong>Q.</strong> Are there other environment variables I can add to my Chainlink node?</p>
 </div>
 <div class="paragraph">
-<p><strong>A.</strong> Yes, you can find a list of the environment variables and explanation at the <a href="https://docs.chain.link/docs/configuration-variables/">configuration variables documentation</a>.</p>
+<p><strong>A.</strong> Yes. To see a list of environment variables and their explanations, see <a href="https://docs.chain.link/docs/configuration-variables/">Configuration Variables</a>.</p>
 </div>
 <div class="paragraph">
-<p><strong>Q.</strong> I encountered a <strong>error reading password: open /chainlink/.password: no such file or directory</strong> error message when starting my Chainlink node.</p>
+<p><strong>Q.</strong> I encountered an <strong>Error reading password: open /chainlink/.password: no such file or directory</strong> error message when starting my Chainlink node.</p>
 </div>
 <div class="paragraph">
-<p><strong>A.</strong> Make sure that the .password files exist inside the Chainlink root directory. If the .password file does not exist, run the command below to create the .password file:</p>
+<p><strong>A.</strong> Make sure that the .password files exist inside the Chainlink root directory. If the .password file does not exist, run the following command to create the .password file:</p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1695,10 +1652,10 @@ $(aws secretsmanager get-secret-value --secret-id WalletSecret --query "SecretSt
 </div>
 </div>
 <div class="paragraph">
-<p><strong>Q.</strong> I encountered a <strong>creating application: parse "XXXXXX": invalid URI for request</strong> error message when starting my Chainlink node.</p>
+<p><strong>Q.</strong> I encountered a <strong>Creating application: parse "XXXXXX": invalid URI for request</strong> error message when starting my Chainlink node.</p>
 </div>
 <div class="paragraph">
-<p><strong>A.</strong> This error typically happens when there is a parsing error within the PostgreSQL connection string (postgresql://) in the DATABASE_URL variable. Double-check the .env file for any errors in format or spelling. You can manually edit the connection string or run the command below to create a new .env file:</p>
+<p><strong>A.</strong> This error typically happens when a parsing error exists within the PostgreSQL connection string (postgresql://) in the DATABASE_URL variable. Double-check the .env file for any errors in format or spelling. You can manually edit the connection string or run the following command to create a new .env file:</p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1711,6 +1668,12 @@ ${psqlHostname} \
 ${psqlPort} \
 ${psqlDb}</pre>
 </div>
+</div>
+<div class="paragraph">
+<p><strong>Q.</strong> Where can I find more information about the Chainlink node deployment?</p>
+</div>
+<div class="paragraph">
+<p><strong>A.</strong> For more information, see <a href="https://docs.chain.link/docs/best-practices-aws/">Best Practices for Deploying Nodes on AWS</a>.</p>
 </div>
 </div>
 </div>
@@ -1752,7 +1715,7 @@ Unless you are customizing the Quick Start templates for your own deployment pro
 <h2 id="_quick_start_reference_deployments">Quick Start reference deployments</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See the <a href="https://aws.amazon.com/quickstart/">AWS Quick Start home page</a>.</p>
+<p>See the <a href="https://aws.amazon.com/quickstart/" target="_blank" rel="noopener">AWS Quick Start home page</a>.</p>
 </div>
 </div>
 </div>

--- a/docs/index_prod.html
+++ b/docs/index_prod.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.15">
-<title>Chainlink node on the AWS Cloud</title>
+<title>Chainlink Node on the AWS Cloud</title>
 <style>
 
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -825,7 +825,7 @@ p.footer-text a{color:#d7d8d8}
 <div id="toctitle"></div>
 <ul class="sectlevel1">
 <li><a href="#_overview">Overview</a></li>
-<li><a href="#_chainlink_node_on_aws">Chainlink node on AWS</a></li>
+<li><a href="#_chainlink_node_on_aws">Chainlink Node on AWS</a></li>
 <li><a href="#_aws_costs">AWS costs</a></li>
 <li><a href="#_software_licenses">Software licenses</a></li>
 <li><a href="#_architecture">Architecture</a></li>
@@ -845,17 +845,17 @@ p.footer-text a{color:#d7d8d8}
 <li><a href="#_post_deployment_steps">Post-deployment steps</a>
 <ul class="sectlevel2">
 <li><a href="#_access_your_chainlink_node">Access your Chainlink node</a></li>
-<li><a href="#_fulfilling_requests_with_the_chainlink_node">Fulfilling requests with the Chainlink node</a></li>
-<li><a href="#_working_with_external_adapters">Working with external adapters</a></li>
-<li><a href="#_manually_creating_your_env_password_and_api_files_for_chainlink_node_instances">Manually creating your .env, .password, and .api files for Chainlink node instances</a></li>
-<li><a href="#_docker_run_command_to_start_chainlink_node_instances">Docker run command to start Chainlink node instances</a></li>
+<li><a href="#_fulfill_requests_with_the_chainlink_node">Fulfill requests with the Chainlink node</a></li>
+<li><a href="#_work_with_external_adapters">Work with external adapters</a></li>
+<li><a href="#_manually_create_files_for_chainlink_node_instances">Manually create files for Chainlink node instances</a></li>
+<li><a href="#_start_chainlink_node_instances">Start Chainlink node instances</a></li>
 </ul>
 </li>
 <li><a href="#_best_practices_for_using_chainlink_node_on_aws">Best practices for using Chainlink node on AWS</a>
 <ul class="sectlevel2">
-<li><a href="#_failover_capabilities">Failover Capabilities</a></li>
-<li><a href="#_disaster_recovery">Disaster Recovery</a></li>
-<li><a href="#_active_monitoring">Active Monitoring</a></li>
+<li><a href="#_failover_capabilities">Failover capabilities</a></li>
+<li><a href="#_disaster_recovery">Disaster recovery</a></li>
+<li><a href="#_active_monitoring">Active monitoring</a></li>
 </ul>
 </li>
 <li><a href="#_security">Security</a></li>
@@ -872,7 +872,7 @@ p.footer-text a{color:#d7d8d8}
 <div id="content">
 <div id="preamble">
 <div class="sectionbody">
-<h2 id="_chainlink_node_on_the_aws_cloud" class="discrete text-center">Chainlink node on the AWS Cloud</h2>
+<h2 id="_chainlink_node_on_the_aws_cloud" class="discrete text-center">Chainlink Node on the AWS Cloud</h2>
 <h2 id="_quick_start_reference_deployment" class="discrete text-left text-center">Quick Start Reference Deployment</h2>
 <div class="imageblock text-center">
 <div class="content">
@@ -880,8 +880,10 @@ p.footer-text a{color:#d7d8d8}
 </div>
 </div>
 <div class="paragraph text-center">
-<p><strong>August 2021</strong><br>
-<em>AWS Quick Start team</em></p>
+<p><strong>September 2021</strong><br>
+<em>David Dang, Rodger Johnson, Chainlink Labs</em><br>
+<em>Vijay Krishnan, AWS Solutions Architect</em><br>
+<em>Troy Ameigh, AWS Solutions Architect, Integration and Automation Team</em></p>
 </div>
 <div class="admonitionblock tip text-left">
 <table>
@@ -908,7 +910,7 @@ report bugs, or submit feature ideas for this Quick Start.
 <p>This guide provides instructions for deploying the Chainlink node Quick Start reference architecture on the AWS Cloud.</p>
 </div>
 <div class="paragraph">
-<p>This Quick Start is for users who enterprise users that want to run a highly available and secure Chainlink node.</p>
+<p>This Quick Start deploys highly available Chainlink nodes with default parameters and a blockchain to the AWS Cloud. It is for enterprise users who want to run a secure Chainlink node to provide external resources such as external APIs, tamper-proof price data, and verifiable randomness directly to smart contracts stored on the blockchain.</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -925,16 +927,16 @@ Amazon may share user-deployment information with the AWS Partner that collabora
 </div>
 </div>
 <div class="sect1">
-<h2 id="_chainlink_node_on_aws">Chainlink node on AWS</h2>
+<h2 id="_chainlink_node_on_aws">Chainlink Node on AWS</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Chainlink is a data oracle that enables smart contracts on any blockchain to leverage extensive off-chain resources, such as tamper-proof price data, verifiable randomness, and external APIs.</p>
+<p>Chainlink is a data oracle that enables smart contracts on any blockchain to take advantage of extensive off-chain resources, such as tamper-proof price data, verifiable randomness, and external APIs.</p>
 </div>
 <div class="paragraph">
-<p>When deployed to a blockchain, a smart contract is a set of instructions that can be executed without intervention from third parties. The code of a smart contract determines how it responds to input, just like the code of any other computer program.</p>
+<p>When deployed to a blockchain, a smart contract is a set of instructions that can be run without intervention from third parties. The code of a smart contract determines how it responds to input, just like the code of any other computer program.</p>
 </div>
 <div class="paragraph">
-<p>The Chainlink node is middleware, operating between the blockchain and external data. Node operators are able to run their Chainlink nodes with oracle job specifications, or specs, which contain the sequential tasks that the node must perform to produce a final result. The Chainlink node provide external data directly to smart contracts.</p>
+<p>The Chainlink node is middleware that operates between the blockchain and external data. Node operators are able to run their Chainlink nodes with oracle job specifications, or specs, which contain the sequential tasks that the node must perform to produce a final result. The Chainlink node provides external data directly to smart contracts.</p>
 </div>
 </div>
 </div>
@@ -983,7 +985,7 @@ AWS Cloud.</p>
 </div>
 <div id="architecture1" class="imageblock">
 <div class="content">
-<img src="images/architecture_diagram_white.png" alt="Architecture">
+<img src="images/chainlink-node-architecture-diagram.png" alt="Architecture">
 </div>
 <div class="title">Figure 1. Quick Start architecture for Chainlink node on AWS</div>
 </div>
@@ -1012,7 +1014,7 @@ internet access for the Chainlink node instances in the private subnets.*</p>
 </li>
 <li>
 <p>A Linux bastion host in an Auto Scaling group to allow inbound Secure
-Shell (SSH) access to EC2 instances in public and private subnets.</p>
+Shell (SSH) access to Amazon Elastic Compute Cloud (Amazon EC2) instances in public and private subnets.</p>
 </li>
 </ul>
 </div>
@@ -1022,28 +1024,25 @@ Shell (SSH) access to EC2 instances in public and private subnets.</p>
 <div class="ulist">
 <ul>
 <li>
-<p>Two Chainlink nodes in an Auto Scaling group.</p>
+<p>Two Chainlink nodes in an Auto Scaling group that contains security groups for fine-grained inbound access control.</p>
 </li>
 <li>
-<p>An Amazon Relation Database Service (Amazon RDS) PostgreSQL managed database instance.</p>
+<p>An Amazon Relational Database Service (Amazon RDS) PostgreSQL managed database instance.</p>
 </li>
 </ul>
 </div>
 </li>
 <li>
-<p>Security groups for fine-grained inbound access control.</p>
-</li>
-<li>
-<p>An Elastic Load Balancing (ELB) load balancer to access the Chainlink node web graphical user interface.</p>
+<p>An Elastic Load Balancing (ELB) load balancer to access the Chainlink node user interface.</p>
 </li>
 <li>
 <p>Amazon CloudWatch logging of Chainlink nodes.</p>
 </li>
 <li>
-<p>AWS managed keys and customer managed keys for resources with AWS Key Management Service (KMS).</p>
+<p>AWS Key Management Service (AWS KMS) resources with both AWS managed and customer managed keys.</p>
 </li>
 <li>
-<p>AWS Secrets Manager to store your credentials.</p>
+<p>AWS Secrets Manager to store credentials.</p>
 </li>
 <li>
 <p>Amazon DevOps Guru tracking of your Chainlink node stack.</p>
@@ -1067,35 +1066,32 @@ and <a href="https://aws.amazon.com/training/" target="_blank" rel="noopener">AW
 deploy, and operate your infrastructure and applications on the AWS Cloud.</p>
 </div>
 <div class="paragraph">
-<p>This Quick Start also assumes familiarity with basic concepts in the areas of networking and DevOps. This deployment guide also requires a moderate level of familiarity with AWS services.</p>
+<p>This Quick Start assumes familiarity with networking, DevOps, and <a href="https://docs.chain.link/docs/running-a-chainlink-node/" target="_blank" rel="noopener">Chainlink nodes</a>. It also requires a moderate level of familiarity with the following AWS services:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p><a href="https://aws.amazon.com/ec2/">Amazon EC2</a></p>
+<p><a href="https://aws.amazon.com/ec2/" target="_blank" rel="noopener">Amazon EC2</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/vpc/">Amazon VPC</a></p>
+<p><a href="https://aws.amazon.com/vpc/" target="_blank" rel="noopener">Amazon VPC</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/cloudwatch/">Amazon CloudWatch</a></p>
+<p><a href="https://aws.amazon.com/cloudwatch/" target="_blank" rel="noopener">Amazon CloudWatch</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/devops-guru/">Amazon DevOps Guru</a></p>
+<p><a href="https://aws.amazon.com/devops-guru/" target="_blank" rel="noopener">Amazon DevOps Guru</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/rds/aurora/?aurora-whats-new.sort-by=item.additionalFields.postDateTime&amp;aurora-whats-new.sort-order=desc">Amazon Aurora PostgreSQL</a></p>
+<p><a href="https://aws.amazon.com/rds/aurora/?aurora-whats-new.sort-by=item.additionalFields.postDateTime&amp;aurora-whats-new.sort-order=desc" target="_blank" rel="noopener">Amazon Aurora PostgreSQL</a></p>
 </li>
 <li>
-<p><a href="https://aws.amazon.com/cloudformation/">AWS CloudFormation</a></p>
+<p><a href="https://aws.amazon.com/cloudformation/" target="_blank" rel="noopener">AWS CloudFormation</a></p>
 </li>
 </ul>
 </div>
 <div class="paragraph">
-<p>If you’re new to AWS, visit the <a href="https://aws.amazon.com/getting-started/">Getting Started Resource Center</a> and the <a href="https://aws.amazon.com/training/">AWS Training and Certification</a> for materials and programs that can help you develop the skills to design, deploy, and operate your infrastructure and applications on the AWS Cloud.</p>
-</div>
-<div class="paragraph">
-<p>We recommend that you also become familiar with running <a href="https://docs.chain.link/docs/running-a-chainlink-node/">Chainlink nodes</a>.</p>
+<p>If you’re new to AWS, see the <a href="https://aws.amazon.com/getting-started/" target="_blank" rel="noopener">Getting Started Resource Center</a> and the <a href="https://aws.amazon.com/training/" target="_blank" rel="noopener">AWS Training and Certification</a> site for materials and programs that can help you develop the skills to design, deploy, and operate your infrastructure and applications on the AWS Cloud.</p>
 </div>
 </div>
 <div class="sect2">
@@ -1169,40 +1165,12 @@ deploy, and operate your infrastructure and applications on the AWS Cloud.</p>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_supported_regions">Supported Regions</h4>
+<h4 id="_supported_aws_regions">Supported AWS Regions</h4>
 <div class="paragraph">
-<p>This Quick Start supports the following Regions:</p>
+<p>For any Quick Start to work in a Region other than its default Region, all the services it deploys must be supported in that Region. You can launch a Quick Start in any Region and see if it works. If you get an error such as “Unrecognized resource type,” the Quick Start is not supported in that Region.</p>
 </div>
-<div class="ulist">
-<ul>
-<li>
-<p>us-east-1, US East (N. Virginia)</p>
-</li>
-<li>
-<p>us-east-2, US East (Ohio)</p>
-</li>
-<li>
-<p>us-west-2, US West (Oregon)</p>
-</li>
-<li>
-<p>eu-central-1, Europe (Frankfurt)</p>
-</li>
-<li>
-<p>eu-west-1, Europe (Ireland)</p>
-</li>
-<li>
-<p>eu-north-1, Europe (Stockholm)</p>
-</li>
-<li>
-<p>ap-southeast-1, Asia Pacific (Singapore)</p>
-</li>
-<li>
-<p>ap-southeast-2, Asia Pacific (Tokyo)</p>
-</li>
-<li>
-<p>ap-northeast-1, Asia Pacific (Tokyo)</p>
-</li>
-</ul>
+<div class="paragraph">
+<p>For an up-to-date list of AWS Regions and the AWS services they support, see <a href="https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/" target="_blank" rel="noopener">AWS Regional Services</a>.</p>
 </div>
 <div class="admonitionblock tip">
 <table>
@@ -1224,29 +1192,6 @@ Certain Regions are available on an opt-in basis. For more information, see <a h
 </div>
 </div>
 <div class="sect3">
-<h4 id="_prepare_your_aws_account">Prepare your AWS account</h4>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>If you don’t already have an AWS account, create one at <a href="https://aws.amazon.com" class="bare">https://aws.amazon.com</a> by
-following the on-screen instructions.</p>
-</li>
-<li>
-<p>Create a key pair in your preferred region.</p>
-</li>
-<li>
-<p>If using a domain and SSL certificate, create a public certificate using Amazon Certificate Manager in your preferred region.</p>
-</li>
-<li>
-<p>Run a blockchain client or use a third party client. In the case of a third party Ethereum client, you can use the websocket endpoint from <a href="https://infura.io/docs/ethereum/wss/introduction.md">Infura</a> or <a href="https://docs.fiews.io/docs/getting-started">Fiews</a>. For other Ethereum clients, visit <a href="https://docs.chain.link/docs/run-an-ethereum-client/">Run an Ethereum Client</a>.</p>
-</li>
-<li>
-<p>If using an existing VPC, make sure that it contains two public subnets, two private subnets, internet gateway, NAT gateways, and route tables.</p>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect3">
 <h4 id="_deployment_options">Deployment options</h4>
 <div class="paragraph">
 <p>This Quick Start provides two deployment options:</p>
@@ -1263,6 +1208,29 @@ following the on-screen instructions.</p>
 </div>
 <div class="paragraph">
 <p>The Quick Start provides separate templates for these options. It also lets you configure Classless Inter-Domain Routing (CIDR) blocks, instance types, and Chainlink node settings, as discussed later in this guide.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_prepare_your_aws_account">Prepare your AWS account</h4>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Create an AWS account at <a href="https://aws.amazon.com" class="bare">https://aws.amazon.com</a> by
+following the on-screen instructions.</p>
+</li>
+<li>
+<p>Create a key pair in your preferred Region.</p>
+</li>
+<li>
+<p>If using a domain and SSL certificate, create a public certificate using AWS Certificate Manager (ACM) in your preferred Region.</p>
+</li>
+<li>
+<p>Run a blockchain client or use a third-party client. If using a third-party Ethereum client, you can use the web socket endpoint from <a href="https://infura.io/docs/ethereum/wss/introduction.md" target="_blank" rel="noopener">Infura</a> or <a href="https://docs.fiews.io/docs/getting-started" target="_blank" rel="noopener">Fiews</a>. For other Ethereum clients, see <a href="https://docs.chain.link/docs/run-an-ethereum-client/" target="_blank" rel="noopener">Run an Ethereum Client</a>.</p>
+</li>
+<li>
+<p>If using an existing VPC, make sure that it contains two public subnets, two private subnets, an internet gateway, NAT gateways, and route tables.</p>
+</li>
+</ol>
 </div>
 </div>
 </div>
@@ -1310,17 +1278,17 @@ If you’re deploying Chainlink node into an existing VPC, make sure that your V
 <p>Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see <a href="#_deployment_options">Deployment options</a> earlier in this guide.</p>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 75%;">
-<col style="width: 25%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="http://qs_launch_permalink" target="_blank" rel="noopener">Deploy Chainlink node into a new VPC on AWS</a></p></td>
-<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="http://qs_template_permalink" target="_blank" rel="noopener">View template</a></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="https://fwd.aws/VVEab?" target="_blank" rel="noopener">Deploy Chainlink node into a new VPC on AWS</a></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="https://fwd.aws/8bA3e?" target="_blank" rel="noopener">View template</a></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="http://qs_launch_permalink" target="_blank" rel="noopener">Deploy Chainlink node into an existing VPC on AWS</a></p></td>
-<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="http://qs_template_permalink" target="_blank" rel="noopener">View template</a></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="https://fwd.aws/Veavz?" target="_blank" rel="noopener">Deploy Chainlink node into an existing VPC on AWS</a></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><a href="https://fwd.aws/aX4v6?" target="_blank" rel="noopener">View template</a></p></td>
 </tr>
 </tbody>
 </table>
@@ -1335,7 +1303,7 @@ If you’re deploying Chainlink node into an existing VPC, make sure that your V
 <p>On the <strong>Specify stack details</strong> page, change the stack name if needed. Review the parameters for the template. Provide values for the parameters that require input. For all other parameters, review the default settings and customize them as necessary. For details on each parameter, see the <a href="#_parameter_reference">Parameter reference</a> section of this guide. When you finish reviewing and customizing the parameters, choose <strong>Next</strong>.</p>
 </li>
 <li>
-<p>On the <strong>Configure stack options</strong> page, you can <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html" target="_blank" rel="noopener">specify tags</a> (key-value pairs) for resources in your stack and <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html" target="_blank" rel="noopener">set advanced options</a>. When you’re finished, choose <strong>Next</strong>.</p>
+<p>On the <strong>Configure stack options</strong> page, you can <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html" target="_blank" rel="noopener">specify tags</a> (key-value pairs) for resources in your stack and <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html" target="_blank" rel="noopener">set advanced options</a>. When you finish, choose <strong>Next</strong>.</p>
 </li>
 <li>
 <p>On the <strong>Review</strong> page, review and confirm the template settings. Under <strong>Capabilities</strong>, select the two check boxes to acknowledge that the template creates IAM resources and might require the ability to automatically expand macros.</p>
@@ -1360,17 +1328,13 @@ If you’re deploying Chainlink node into an existing VPC, make sure that your V
 <div class="sect2">
 <h3 id="_access_your_chainlink_node">Access your Chainlink node</h3>
 <div class="paragraph">
-<p>You can access your Chainlink node through the web graphical user interface. There are two options on accessing the page.</p>
+<p>You can access the Chainlink node user interface (UI) using one of the following options:</p>
 </div>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>If using a domain and SSL certificate created through AWS Certificate Manager, you can access the Chainlink node web GUI through the application load balancer endpoint or through your domain by adding the load balancer endpoint to your domain&#8217;s DNS record.</p>
-</li>
-<li>
-<p>By enabling TCP port forwarding on your bastion host, you are able to port forward the Chainlink node web GUI to your machine. As we are accessing the Chainlink node through a bastion, it is recommended to use SSH agent forwarding. Then connect to your bastion with SSH agent and TCP port forwarding. You can access the Chainlink node web GUI at <a href="http://localhost:6688/" class="bare">http://localhost:6688/</a>.</p>
-</li>
-</ol>
+<div class="paragraph">
+<p>Option 1: If using a domain and SSL certificate created through ACM, you can access the Chainlink node UI through the Application Load Balancer endpoint or through your domain by adding the load balancer endpoint to your domain&#8217;s DNS record.</p>
+</div>
+<div class="paragraph">
+<p>Option 2: Allow TCP port forwarding on your bastion host to port forward the Chainlink node UI to your machine. When accessing the Chainlink node through a bastion host, use SSH agent forwarding. Then connect to your bastion host with an SSH agent and TCP port forwarding. Access the Chainlink node UI at <a href="http://localhost:6688/" class="bare">http://localhost:6688/</a>.</p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1381,24 +1345,24 @@ ssh ec2-user@&lt;chainlink_node_internal_ip&gt; -L 6688:localhost:6688</pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_fulfilling_requests_with_the_chainlink_node">Fulfilling requests with the Chainlink node</h3>
+<h3 id="_fulfill_requests_with_the_chainlink_node">Fulfill requests with the Chainlink node</h3>
 <div class="paragraph">
-<p>Once the quickstart is deployed, your Chainlink node is ready to interact with smart contracts and <a href="https://docs.chain.link/docs/fulfilling-requests/">fulfill requests</a>.</p>
+<p>After the Quick Start is deployed, your Chainlink node is ready to interact with smart contracts and fulfill requests. For more information, see <a href="https://docs.chain.link/docs/fulfilling-requests/" target="_blank" rel="noopener">Fulfilling Requests</a>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_working_with_external_adapters">Working with external adapters</h3>
+<h3 id="_work_with_external_adapters">Work with external adapters</h3>
 <div class="paragraph">
-<p>External adapters are how Chainlink enables easy integration of custom computations and specialized APIs. External adapters are services which the core of the Chainlink node communicates via its API with a simple JSON specification. To get started, visit our <a href="https://docs.chain.link/docs/external-adapters/">external adapters documentation</a>.</p>
+<p>Chainlink enables integration of custom computations and specialized APIs using external adapters. The Chainlink node communicates with external adapter services via an API using a JSON specification. To get started, see <a href="https://docs.chain.link/docs/external-adapters/" target="_blank" rel="noopener">External Adapters Introduction</a>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_manually_creating_your_env_password_and_api_files_for_chainlink_node_instances">Manually creating your .env, .password, and .api files for Chainlink node instances</h3>
+<h3 id="_manually_create_files_for_chainlink_node_instances">Manually create files for Chainlink node instances</h3>
 <div class="paragraph">
-<p>If the Chainlink node instances are stopped, then new .env, .password, and .api files will need to be created to start the Chainlink node.</p>
+<p>If the Chainlink node instances are stopped, then you must create new .env, .password, and .api files to start the Chainlink node.</p>
 </div>
 <div class="paragraph">
-<p><strong>Generating the .env file:</strong></p>
+<p><strong>Generate the .env file:</strong></p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1413,7 +1377,7 @@ ${psqlDb}</pre>
 </div>
 </div>
 <div class="paragraph">
-<p><strong>Generating the .password file:</strong></p>
+<p><strong>Generate the .password file:</strong></p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1422,7 +1386,7 @@ $(aws secretsmanager get-secret-value --secret-id WalletSecret --query "SecretSt
 </div>
 </div>
 <div class="paragraph">
-<p><strong>Generating the .api file:</strong></p>
+<p><strong>Generate the .api file:</strong></p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1433,9 +1397,9 @@ $(aws secretsmanager get-secret-value --secret-id ApiSecret --query "SecretStrin
 </div>
 </div>
 <div class="sect2">
-<h3 id="_docker_run_command_to_start_chainlink_node_instances">Docker run command to start Chainlink node instances</h3>
+<h3 id="_start_chainlink_node_instances">Start Chainlink node instances</h3>
 <div class="paragraph">
-<p>To manually run the latest image of Chainlink node docker instance:</p>
+<p>To run the latest image of the Chainlink node Docker instance, run this command:</p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1444,11 +1408,12 @@ cd /home/ec2-user/.chainlink &amp;&amp; docker run -d \
 --log-driver=awslogs \
 --log-opt awslogs-group=ChainlinkLogs \
 --restart unless-stopped \
+-u 1000:1000 \
 --name chainlink \
 -p 6688:6688 \
 -v /home/ec2-user/.chainlink:/chainlink \
 --env-file=/home/ec2-user/.chainlink/.env  smartcontract/chainlink:$latestimage local n \
--p /chainlink/.password
+-p /chainlink/.password \
 -a /chainlink/.api</pre>
 </div>
 </div>
@@ -1459,59 +1424,56 @@ cd /home/ec2-user/.chainlink &amp;&amp; docker run -d \
 <h2 id="_best_practices_for_using_chainlink_node_on_aws">Best practices for using Chainlink node on AWS</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_failover_capabilities">Failover Capabilities</h3>
+<h3 id="_failover_capabilities">Failover capabilities</h3>
 <div class="paragraph">
-<p>To ensure there is very minimal downtime, failover capabilities are required on both the Chainlink and Ethereum clients so that if any one server fails, the service is still online. The Amazon EC2 Auto Scaling group has two Chainlink nodes: one active Chainlink node and one standby Chainlink node. Data from both the Chainlink and Ethereum clients are stored in a PostgreSQL database which needs to be highly available.</p>
+<p>To reduce downtime, failover capabilities are required on both the Chainlink and Ethereum clients so that if one server fails, the service is still online. The Amazon EC2 Auto Scaling group has two Chainlink nodes: one active Chainlink node and one standby Chainlink node. Data from both the Chainlink and Ethereum clients are stored in a highly available PostgreSQL database.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_disaster_recovery">Disaster Recovery</h3>
+<h3 id="_disaster_recovery">Disaster recovery</h3>
 <div class="paragraph">
-<p>Problems occur and when they do, the right processes need to be in-place to ensure that as little downtime as possible occurs. The main impediment to incurring large amounts of downtime in the context of Chainlink node operators is a fully corrupted Ethereum node that requires a re-sync.</p>
+<p>If problems occur, the right processes must be in place to reduce downtime. The most common reason for downtime (in the context of Chainlink node operators) is a corrupted Ethereum node that requires a resynchronization.</p>
 </div>
 <div class="paragraph">
-<p>Due to the challenge of recovering an Ethereum client, we recommend:</p>
+<p>To recover an Ethereum client and reduce downtime, follow these recommendations:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p>Daily snapshots of the Ethereum chain on a separate server than what the Chainlink node is connected to.</p>
+<p>Take daily snapshots of the Ethereum chain on a separate server than the one connected to the Chainlink node.</p>
 </li>
 <li>
-<p>An Ethereum client start-up process that pulls down the latest template of the chain and syncs it to the latest height.</p>
+<p>Use an Ethereum client start-up process that pulls down the latest template of the chain and syncs it to the latest height.</p>
 </li>
 </ul>
 </div>
-<div class="paragraph">
-<p>With this process in-place, the elapsed time of full disaster is kept to a minimum.</p>
-</div>
 </div>
 <div class="sect2">
-<h3 id="_active_monitoring">Active Monitoring</h3>
+<h3 id="_active_monitoring">Active monitoring</h3>
 <div class="paragraph">
-<p>To be proactive in detecting any issues before or when they occur, active monitoring needs to be in place. The areas where we recommend to monitor are:</p>
+<p>To detect issues before or when they occur, use active monitoring in the following areas:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p>(Minimum Required) ETH balance of the wallet address assigned to the node.</p>
+<p>(Minimum required) Ethereum of the wallet address assigned to the node.</p>
 </li>
 <li>
 <p>Errored job runs.</p>
 </li>
 <li>
-<p>Operator UI port to be open and responsive. (Usually: 6688)</p>
+<p>Operator UI port to be open and responsive (usually 6688).</p>
 </li>
 <li>
-<p>Ethereum http and websocket ports to be open and responsive. (Usually: 8545 &amp; 8546)</p>
+<p>Ethereum HTTP and web socket ports to be open and responsive (usually 8545 and 8546).</p>
 </li>
 <li>
-<p>Ethereum client disk, RAM and CPU usage.</p>
+<p>Ethereum client disk, RAM, and CPU usage.</p>
 </li>
 </ul>
 </div>
 <div class="paragraph">
-<p>Monitoring of the Chainlink nodes are available through Amazon CloudWatch.</p>
+<p>You can use Amazon CloudWatch to monitor Chainlink nodes.</p>
 </div>
 </div>
 </div>
@@ -1520,7 +1482,7 @@ cd /home/ec2-user/.chainlink &amp;&amp; docker run -d \
 <h2 id="_security">Security</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>The Chainlink node docker instance requires the .env, .password, and .api file that contains plaintext passwords. It is recommended to remove the .env, .password, and .api files once the Chainlink node instance is running to prevent potential exposure of sensitive passwords.</p>
+<p>The Chainlink node Docker instance requires the .env, .password, and .api file that contains plaintext passwords. Remove the .env, .password, and .api files after the Chainlink node instance is running to prevent potential exposure of sensitive passwords.</p>
 </div>
 </div>
 </div>
@@ -1558,13 +1520,13 @@ When you set <strong>Rollback on failure</strong> to <strong>Disabled</strong>, 
 <p><strong>Q.</strong> Are there other environment variables I can add to my Chainlink node?</p>
 </div>
 <div class="paragraph">
-<p><strong>A.</strong> Yes, you can find a list of the environment variables and explanation at the <a href="https://docs.chain.link/docs/configuration-variables/">configuration variables documentation</a>.</p>
+<p><strong>A.</strong> Yes. To see a list of environment variables and their explanations, see <a href="https://docs.chain.link/docs/configuration-variables/">Configuration Variables</a>.</p>
 </div>
 <div class="paragraph">
-<p><strong>Q.</strong> I encountered a <strong>error reading password: open /chainlink/.password: no such file or directory</strong> error message when starting my Chainlink node.</p>
+<p><strong>Q.</strong> I encountered an <strong>Error reading password: open /chainlink/.password: no such file or directory</strong> error message when starting my Chainlink node.</p>
 </div>
 <div class="paragraph">
-<p><strong>A.</strong> Make sure that the .password files exist inside the Chainlink root directory. If the .password file does not exist, run the command below to create the .password file:</p>
+<p><strong>A.</strong> Make sure that the .password files exist inside the Chainlink root directory. If the .password file does not exist, run the following command to create the .password file:</p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1573,10 +1535,10 @@ $(aws secretsmanager get-secret-value --secret-id WalletSecret --query "SecretSt
 </div>
 </div>
 <div class="paragraph">
-<p><strong>Q.</strong> I encountered a <strong>creating application: parse "XXXXXX": invalid URI for request</strong> error message when starting my Chainlink node.</p>
+<p><strong>Q.</strong> I encountered a <strong>Creating application: parse "XXXXXX": invalid URI for request</strong> error message when starting my Chainlink node.</p>
 </div>
 <div class="paragraph">
-<p><strong>A.</strong> This error typically happens when there is a parsing error within the PostgreSQL connection string (postgresql://) in the DATABASE_URL variable. Double-check the .env file for any errors in format or spelling. You can manually edit the connection string or run the command below to create a new .env file:</p>
+<p><strong>A.</strong> This error typically happens when a parsing error exists within the PostgreSQL connection string (postgresql://) in the DATABASE_URL variable. Double-check the .env file for any errors in format or spelling. You can manually edit the connection string or run the following command to create a new .env file:</p>
 </div>
 <div class="literalblock">
 <div class="content">
@@ -1589,6 +1551,12 @@ ${psqlHostname} \
 ${psqlPort} \
 ${psqlDb}</pre>
 </div>
+</div>
+<div class="paragraph">
+<p><strong>Q.</strong> Where can I find more information about the Chainlink node deployment?</p>
+</div>
+<div class="paragraph">
+<p><strong>A.</strong> For more information, see <a href="https://docs.chain.link/docs/best-practices-aws/">Best Practices for Deploying Nodes on AWS</a>.</p>
 </div>
 </div>
 </div>
@@ -1629,7 +1597,7 @@ Unless you are customizing the Quick Start templates for your own deployment pro
 <h2 id="_quick_start_reference_deployments">Quick Start reference deployments</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>See the <a href="https://aws.amazon.com/quickstart/">AWS Quick Start home page</a>.</p>
+<p>See the <a href="https://aws.amazon.com/quickstart/" target="_blank" rel="noopener">AWS Quick Start home page</a>.</p>
 </div>
 </div>
 </div>

--- a/docs/partner_editable/additional_info.adoc
+++ b/docs/partner_editable/additional_info.adoc
@@ -56,11 +56,12 @@ cd /home/ec2-user/.chainlink && docker run -d \
 --log-driver=awslogs \
 --log-opt awslogs-group=ChainlinkLogs \
 --restart unless-stopped \
+-u 1000:1000 \ 
 --name chainlink \
 -p 6688:6688 \
 -v /home/ec2-user/.chainlink:/chainlink \
 --env-file=/home/ec2-user/.chainlink/.env  smartcontract/chainlink:$latestimage local n \
--p /chainlink/.password
+-p /chainlink/.password \
 -a /chainlink/.api
 ....
 

--- a/templates/quickstart-chainlink-node.template.yaml
+++ b/templates/quickstart-chainlink-node.template.yaml
@@ -459,6 +459,7 @@ Resources:
                 --log-driver=awslogs \
                 --log-opt awslogs-group=ChainlinkLogs \
                 --restart unless-stopped \
+                -u 1000:1000 \
                 --name chainlink \
                 -p 6688:6688 \
                 -v /home/ec2-user/.chainlink:/chainlink \


### PR DESCRIPTION
*Issue #, if available:*
- Error in a command in docs
- Chainlink node container latest release breaking change requires docker run with a non-root user

*Description of changes:*
- Updated documentation and code to use default user `-u 1000:1000` when running Chainlink node container
- Added the missing `\` to docker run command in docs:
```
-p /chainlink/.password \
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
