### PR TITLE
Fix Chain Mismatch across YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## ChainlinkLabds ChainLink Node on the AWS Cloud—Quick Start
+## ChainlinkLabs ChainLink Node on the AWS Cloud—Quick Start
 
 For architectural details, step-by-step instructions, and customization options, see the [deployment guide](http://aws-quickstart.github.io/quickstart-chainlinklabs-chainlink-node/).
 

--- a/templates/quickstart-chainlink-node-workload.template.yaml
+++ b/templates/quickstart-chainlink-node-workload.template.yaml
@@ -301,10 +301,23 @@ Parameters:
       - ETH-Mainnet
       - Kovan-ETH-Testnet
       - Rinkeby-ETH-Testnet
-      - xDai-Mainnet
+      - Gnosis-Chain-Mainnet
       - Heco-Mainnet
       - BSC-Mainnet
+      - BSC-Testnet
       - Matic-Mainnet
+      - Matic-Mumbai-Testnet
+      - Avalanche-Mainnet
+      - Avalanche-Fuji-Testnet
+      - Fantom-Mainnet
+      - Fantom-Testnet
+      - Arbitrum-Mainnet
+      - Arbitrum-Rinkeby-Testnet
+      - Optimism-Mainnet
+      - Optimism-Kovan-Testnet
+      - Harmony-Mainnet
+      - Harmony-Testnet
+      - Moonriver-Mainnet
     Default: Kovan-ETH-Testnet
     Description: 'Blockchain network to run the Chainlink node.'
     Type: String

--- a/templates/quickstart-chainlink-node.template.yaml
+++ b/templates/quickstart-chainlink-node.template.yaml
@@ -185,10 +185,23 @@ Parameters:
       - ETH-Mainnet
       - Kovan-ETH-Testnet
       - Rinkeby-ETH-Testnet
-      - xDai-Mainnet
+      - Gnosis-Chain-Mainnet
       - Heco-Mainnet
       - BSC-Mainnet
+      - BSC-Testnet
       - Matic-Mainnet
+      - Matic-Mumbai-Testnet
+      - Avalanche-Mainnet
+      - Avalanche-Fuji-Testnet
+      - Fantom-Mainnet
+      - Fantom-Testnet
+      - Arbitrum-Mainnet
+      - Arbitrum-Rinkeby-Testnet
+      - Optimism-Mainnet
+      - Optimism-Kovan-Testnet
+      - Harmony-Mainnet
+      - Harmony-Testnet
+      - Moonriver-Mainnet
     Description: 'Blockchain Network to run Chainlink Node.'
     Type: String
   ChainlinkNodeGUIEmail:


### PR DESCRIPTION
*Issue #, if available:*
#30 

*Description of changes:*
The chain list does not match across the template YAML files. This PR adds the missing chains to:
`quickstart-chainlink-node.yaml`
and
`quickstart-chainlink-node-workload.yaml`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
