### PR TITLE
remove kovan and rinkeby testnets, add goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-## ChainlinkLabds ChainLink Node on the AWS Cloud—Quick Start
+## ChainlinkLabs ChainLink Node on the AWS Cloud—Quick Start
 
 For architectural details, step-by-step instructions, and customization options, see the [deployment guide](http://aws-quickstart.github.io/quickstart-chainlinklabs-chainlink-node/).
 
-To post feedback, submit feature ideas, or report bugs, use the **Issues** section of this GitHub repo. 
+To post feedback, submit feature ideas, or report bugs, use the **Issues** section of this GitHub repo.
 
 To submit code for this Quick Start, see the [AWS Quick Start Contributor's Kit](https://aws-quickstart.github.io/).

--- a/scripts/create-env.sh
+++ b/scripts/create-env.sh
@@ -5,13 +5,9 @@ case $1 in
     chain=1
     contractAddress=0x514910771af9ca656af840dff83e8264ecf986ca
     ;;
-  Kovan-ETH-Testnet )
-    chain=42
-    contractAddress=0xa36085F69e2889c224210F603D836748e7dC0088
-    ;;
-  Rinkeby-ETH-Testnet )
-    chain=4
-    contractAddress=0x01BE23585060835E02B77ef475b0Cc51aA1e0709
+  Goerli-ETH-Testnet )
+    chain=5
+    contractAddress=0x326C977E6efc84E512bB9C30f76E30c160eD06FB
     ;;
   Gnosis-Chain-Mainnet )
     chain=100
@@ -57,17 +53,17 @@ case $1 in
     chain=42161
     contractAddress=0xf97f4df75117a78c1A5a0DBb814Af92458539FB4
     ;;
-  Arbitrum-Rinkeby-Testnet )
-    chain=421611
-    contractAddress=0x615fBe6372676474d9e6933d310469c9b68e9726
+  Arbitrum-Goerli-Testnet )
+    chain=421613
+    contractAddress=0xd14838a68e8afbade5efb411d5871ea0011afd28
     ;;
   Optimism-Mainnet )
     chain=10
     contractAddress=0x350a791Bfc2C21F9Ed5d10980Dad2e2638ffa7f6
     ;;
-  Optimism-Kovan-Testnet )
-    chain=69
-    contractAddress=0x4911b761993b9c8c0d14Ba2d86902AF6B0074F5B
+  Optimism-Goerli-Testnet )
+    chain=420
+    contractAddress=0xdc2CC710e42857672E7907CF474a69B63B93089f
     ;;
   Harmony-Mainnet )
     chain=1666600000

--- a/templates/quickstart-chainlink-node-entrypoint.template.yaml
+++ b/templates/quickstart-chainlink-node-entrypoint.template.yaml
@@ -323,8 +323,7 @@ Parameters:
   BlockchainNetwork:
     AllowedValues:
       - ETH-Mainnet
-      - Kovan-ETH-Testnet
-      - Rinkeby-ETH-Testnet
+      - Goerli-ETH-Testnet
       - Gnosis-Chain-Mainnet
       - Heco-Mainnet
       - BSC-Mainnet
@@ -336,13 +335,13 @@ Parameters:
       - Fantom-Mainnet
       - Fantom-Testnet
       - Arbitrum-Mainnet
-      - Arbitrum-Rinkeby-Testnet
+      - Arbitrum-Goerli-Testnet
       - Optimism-Mainnet
-      - Optimism-Kovan-Testnet
+      - Optimism-Goerli-Testnet
       - Harmony-Mainnet
       - Harmony-Testnet
       - Moonriver-Mainnet
-    Default: Kovan-ETH-Testnet
+    Default: Goerli-ETH-Testnet
     Description: 'Blockchain network to run Chainlink node.'
     Type: String
   ChainlinkNodeGUIEmail:

--- a/templates/quickstart-chainlink-node-workload.template.yaml
+++ b/templates/quickstart-chainlink-node-workload.template.yaml
@@ -299,13 +299,25 @@ Parameters:
   BlockchainNetwork:
     AllowedValues:
       - ETH-Mainnet
-      - Kovan-ETH-Testnet
-      - Rinkeby-ETH-Testnet
-      - xDai-Mainnet
+      - Goerli-ETH-Testnet
+      - Gnosis-Chain-Mainnet
       - Heco-Mainnet
       - BSC-Mainnet
+      - BSC-Testnet
       - Matic-Mainnet
-    Default: Kovan-ETH-Testnet
+      - Matic-Mumbai-Testnet
+      - Avalanche-Mainnet
+      - Avalanche-Fuji-Testnet
+      - Fantom-Mainnet
+      - Fantom-Testnet
+      - Arbitrum-Mainnet
+      - Arbitrum-Goerli-Testnet
+      - Optimism-Mainnet
+      - Optimism-Goerli-Testnet
+      - Harmony-Mainnet
+      - Harmony-Testnet
+      - Moonriver-Mainnet
+    Default: Goerli-ETH-Testnet
     Description: 'Blockchain network to run the Chainlink node.'
     Type: String
   ChainlinkNodeGUIEmail:

--- a/templates/quickstart-chainlink-node.template.yaml
+++ b/templates/quickstart-chainlink-node.template.yaml
@@ -183,12 +183,25 @@ Parameters:
   BlockchainNetwork:
     AllowedValues:
       - ETH-Mainnet
-      - Kovan-ETH-Testnet
-      - Rinkeby-ETH-Testnet
-      - xDai-Mainnet
+      - Goerli-ETH-Testnet
+      - Gnosis-Chain-Mainnet
       - Heco-Mainnet
       - BSC-Mainnet
+      - BSC-Testnet
       - Matic-Mainnet
+      - Matic-Mumbai-Testnet
+      - Avalanche-Mainnet
+      - Avalanche-Fuji-Testnet
+      - Fantom-Mainnet
+      - Fantom-Testnet
+      - Arbitrum-Mainnet
+      - Arbitrum-Goerli-Testnet
+      - Optimism-Mainnet
+      - Optimism-Goerli-Testnet
+      - Harmony-Mainnet
+      - Harmony-Testnet
+      - Moonriver-Mainnet
+    Default: Goerli-ETH-Testnet
     Description: 'Blockchain Network to run Chainlink Node.'
     Type: String
   ChainlinkNodeGUIEmail:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-quickstart/quickstart-chainlinklabs-chainlink-node/issues/30

*Description of changes:*
- Copys the chain info from `templates/quickstart-chainlink-node-entrypoint.template.yaml` to `templates/quickstart-chainlink-node-workload.template.yaml` and `templates/quickstart-chainlink-node.template.yaml` that were missing.
- Removes Kovan and Rinkeby networks from ETH, Optimism, and Arbitrum.
- Adds Goerli for ETH, Optimism, and Arbitrum addresses from https://docs.chain.link/docs/link-token-contracts/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
