### PR TITLE
Updated docs and QS deployment to compatible static release

### DIFF
--- a/docs/partner_editable/additional_info.adoc
+++ b/docs/partner_editable/additional_info.adoc
@@ -48,19 +48,19 @@ $(aws secretsmanager get-secret-value --secret-id ApiSecret --query "SecretStrin
 ....
 
 === Start {partner-product-short-name} instances
-To run the latest image of the {partner-product-short-name} Docker instance, run this command:
+To run the latest image supporting environment variables of the {partner-product-short-name} Docker instance, run this command:
 
 ....
-latestimage=$(curl -s -S "https://registry.hub.docker.com/v2/repositories/smartcontract/chainlink/tags/" | jq -r '."results"[]["name"]' | head -n 1)
 cd /home/ec2-user/.chainlink && docker run -d \
 --log-driver=awslogs \
 --log-opt awslogs-group=ChainlinkLogs \
 --restart unless-stopped \
--u 1000:1000 \ 
+-u 14933:14933 \
 --name chainlink \
 -p 6688:6688 \
 -v /home/ec2-user/.chainlink:/chainlink \
---env-file=/home/ec2-user/.chainlink/.env  smartcontract/chainlink:$latestimage local n \
+--env-file=/home/ec2-user/.chainlink/.env \
+public.ecr.aws/chainlink/chainlink:1.12.0 local n \
 -p /chainlink/.password \
 -a /chainlink/.api
 ....

--- a/docs/partner_editable/faq_troubleshooting.adoc
+++ b/docs/partner_editable/faq_troubleshooting.adoc
@@ -47,3 +47,6 @@ ${psqlDb}
 
 *A.* For more information, see https://docs.chain.link/docs/best-practices-aws/[Best Practices for Deploying Nodes on AWS].
 
+*Q.* Why is the {partner-product-short-name} deployment using Chainlink core version 1.12.0?
+
+*A.* The Quick Start deploys the Chainlink node infrastructure using environment variables. Starting with Chainlink core version 2.X.X+, environment variables will be deprecated in place of V2 TOML configuration and secret values. See https://github.com/smartcontractkit/chainlink/blob/develop/docs/CONFIG.md[TOML configuration values] and https://github.com/smartcontractkit/chainlink/blob/develop/docs/SECRETS.md[TOML secret configuration values].

--- a/templates/quickstart-chainlink-node.template.yaml
+++ b/templates/quickstart-chainlink-node.template.yaml
@@ -469,16 +469,16 @@ Resources:
               command: docker pull smartcontract/chainlink:0.9.10
             04-run-chainlink-docker:
               command: |
-                latestimage=$(curl -s -S "https://registry.hub.docker.com/v2/repositories/smartcontract/chainlink/tags/" | jq -r '."results"[]["name"]' | head -n 1)
                 docker run -d \
                 --log-driver=awslogs \
                 --log-opt awslogs-group=ChainlinkLogs \
                 --restart unless-stopped \
-                -u 1000:1000 \
+                -u 14933:14933 \
                 --name chainlink \
                 -p 6688:6688 \
                 -v /home/ec2-user/.chainlink:/chainlink \
-                --env-file=/home/ec2-user/.chainlink/.env  smartcontract/chainlink:${latestimage} local n \
+                --env-file=/home/ec2-user/.chainlink/.env \
+                public.ecr.aws/chainlink/chainlink:1.12.0 local n \
                 -p /chainlink/.password \
                 -a /chainlink/.api
               cwd: "/home/ec2-user/.chainlink"


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Updated deployment to use static and compatible Chainlink core version `1.12.0`
- Switched from dockerhub to public ECR
- Updated UID from `1000` to `14933` to align with container's UID
- Updated documentation for clarity on usage of Chainlink core version `1.12.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
