### PR TITLE
reverted change in uid/gid due to permissions issue

### DIFF
--- a/docs/partner_editable/additional_info.adoc
+++ b/docs/partner_editable/additional_info.adoc
@@ -55,7 +55,7 @@ cd /home/ec2-user/.chainlink && docker run -d \
 --log-driver=awslogs \
 --log-opt awslogs-group=ChainlinkLogs \
 --restart unless-stopped \
--u 14933:14933 \
+-u 1000:1000 \
 --name chainlink \
 -p 6688:6688 \
 -v /home/ec2-user/.chainlink:/chainlink \

--- a/templates/quickstart-chainlink-node.template.yaml
+++ b/templates/quickstart-chainlink-node.template.yaml
@@ -473,7 +473,7 @@ Resources:
                 --log-driver=awslogs \
                 --log-opt awslogs-group=ChainlinkLogs \
                 --restart unless-stopped \
-                -u 14933:14933 \
+                -u 1000:1000 \
                 --name chainlink \
                 -p 6688:6688 \
                 -v /home/ec2-user/.chainlink:/chainlink \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Reverted UID and GID back from `14933:14933` to `1000:1000` in CloudFormation stack and documentation due to permissions error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
